### PR TITLE
Don't set ID on collada nodes.

### DIFF
--- a/src/main/java/de/dfki/asr/atlas/convert/collada/ColladaFolderExporter.java
+++ b/src/main/java/de/dfki/asr/atlas/convert/collada/ColladaFolderExporter.java
@@ -118,7 +118,6 @@ public class ColladaFolderExporter implements ExportOperation<SimpleCOLLADADocum
 	}
 
 	private void setNodeProperties(NodeType node, Folder folder) {
-		node.setId(folder.getName());
 		node.setName(folder.getName());
 		node.setType(NodeEnum.NODE);
 	}


### PR DESCRIPTION
Folder names are free-form, and as such will usually not be valid
XML IDs. For now, there is also no use case where an ID would be
needed on a node, since they are not referenced internally.

Seems to work perfectly fine, too.
