### PR TITLE
Feature/fix multiple shaders

### DIFF
--- a/src/main/java/de/dfki/asr/atlas/business/FolderHasher.java
+++ b/src/main/java/de/dfki/asr/atlas/business/FolderHasher.java
@@ -1,0 +1,133 @@
+/*
+ * This file is part of ATLAS. It is subject to the license terms in
+ * the LICENSE file found in the top-level directory of this distribution.
+ * (Also available at http://www.apache.org/licenses/LICENSE-2.0.txt)
+ * You may not use this file except in compliance with the License.
+ */
+package de.dfki.asr.atlas.business;
+
+import de.dfki.asr.atlas.model.Folder;
+import java.math.BigInteger;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/**
+ * Hash a Folder.
+ *
+ * An ATLAS folder hash is defined as follows:
+ *
+ * collect all child folder hashes.
+ * create a line "# [foldertype]\n"
+ * numerically sort the union of child folder and blob hashes.
+ * if two items have the same hash, sort by type alphabetically ascending.
+ * create lines from the sorted hashes: "[type] [hash]\n"
+ * for folders, the type is "folder", otherwise use the blob type
+ * sort the folder's attributes by their name
+ * create lines from the sorted attributes: "# [name]: [value]"
+ * concatenate all lines and compute a sha1 hash over the text
+ *
+ * Note that, BY DESIGN, this does not include the Folder's name.
+ * Names should be purely descriptive and not correlate with content.
+ * A folder hash is a content-only hash.
+ */
+public class FolderHasher {
+	@lombok.Data
+	@lombok.AllArgsConstructor
+	private static class HashAndType {
+		public String hash;
+		public String type;
+		public static class Compare implements Comparator<HashAndType> {
+			@Override
+			public int compare(HashAndType a, HashAndType b) {
+				BigInteger int_a = new BigInteger(a.hash, 16);
+				BigInteger int_b = new BigInteger(b.hash, 16);
+				int int_result = int_a.compareTo(int_b);
+				if (int_result == 0) {
+					return a.type.compareTo(b.type);
+				}
+				return int_result;
+			}
+		}
+	}
+
+	Folder root;
+	MessageDigest shaDigest;
+	byte[] digest;
+	List<HashAndType> items;
+
+	public FolderHasher(Folder root) {
+		this.items = new LinkedList<>();
+		this.root = root;
+		try {
+			shaDigest = MessageDigest.getInstance("SHA-1");
+		} catch (NoSuchAlgorithmException ex) {
+			// SHA-256 is always available
+			// https://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#MessageDigest
+			throw new RuntimeException(ex);
+		}
+	}
+
+	private void update() {
+		shaDigest.reset();
+		collectContents();
+		shaDigest.update(typeLine().getBytes());
+		shaDigest.update(contentLines().getBytes());
+		shaDigest.update(attributeLines().getBytes());
+		digest = shaDigest.digest();
+	}
+
+	@Override
+	public String toString() {
+		if (digest == null) {
+			update();
+		}
+		return String.format("%040x", new java.math.BigInteger(1, digest));
+	}
+
+	private String typeLine() {
+		return "# " + root.getType() + "\n";
+	}
+
+	private String contentLines() {
+		StringBuilder contentLines = new StringBuilder();
+		Collections.sort(items, new HashAndType.Compare());
+		for (HashAndType item: items) {
+			contentLines.append(item.type);
+			contentLines.append(" ");
+			contentLines.append(item.hash);
+			contentLines.append("\n");
+		}
+		return contentLines.toString();
+	}
+
+	private void collectContents() {
+		for (Map.Entry<String, String> typeAndHash : root.getBlobs().entrySet()) {
+			items.add(new HashAndType(typeAndHash.getValue(), typeAndHash.getKey()));
+		}
+		for (Folder child : root.getChildFolders()) {
+			String hash = new FolderHasher(child).toString();
+			items.add(new HashAndType(hash, "folder"));
+		}
+	}
+
+	private String attributeLines() {
+		SortedMap<String, String> sortedAttrs = new TreeMap<>();
+		sortedAttrs.putAll(root.getAttributes());
+		StringBuilder attributeLines = new StringBuilder();
+		for (Map.Entry<String, String> attribute : sortedAttrs.entrySet()) {
+			attributeLines.append("# ");
+			attributeLines.append(attribute.getKey());
+			attributeLines.append(": ");
+			attributeLines.append(attribute.getValue());
+			attributeLines.append("\n");
+		}
+		return attributeLines.toString();
+	}
+}

--- a/src/main/java/de/dfki/asr/atlas/business/FolderHasher.java
+++ b/src/main/java/de/dfki/asr/atlas/business/FolderHasher.java
@@ -23,8 +23,8 @@ import java.util.TreeMap;
  *
  * An ATLAS folder hash is defined as follows:
  *
+ * create a line "# [folder.type]\n"
  * collect all child folder hashes.
- * create a line "# [foldertype]\n"
  * numerically sort the union of child folder and blob hashes.
  * if two items have the same hash, sort by type alphabetically ascending.
  * create lines from the sorted hashes: "[type] [hash]\n"

--- a/src/main/java/de/dfki/asr/atlas/convert/collada/ColladaMaterialExporter.java
+++ b/src/main/java/de/dfki/asr/atlas/convert/collada/ColladaMaterialExporter.java
@@ -7,6 +7,7 @@
 package de.dfki.asr.atlas.convert.collada;
 
 import de.dfki.asr.atlas.business.AssetManager;
+import de.dfki.asr.atlas.business.FolderHasher;
 import de.dfki.asr.atlas.convert.ExportContext;
 import de.dfki.asr.atlas.model.Blob;
 import de.dfki.asr.atlas.model.Color3D;
@@ -211,6 +212,6 @@ public class ColladaMaterialExporter {
 	}
 
 	private String matrialId(Folder materialFolder) {
-		return materialFolder.getName();
+		return "hash-"+new FolderHasher(materialFolder).toString();
 	}
 }

--- a/src/main/java/de/dfki/asr/atlas/convert/collada/ColladaMaterialExporter.java
+++ b/src/main/java/de/dfki/asr/atlas/convert/collada/ColladaMaterialExporter.java
@@ -45,36 +45,36 @@ public class ColladaMaterialExporter {
 	}
 
 	public void exportMaterial(String assetName, Folder materialFolder, InstanceGeometryType geometryNode, SimpleCOLLADADocument document, String materialSymbol) {
-		String materialName = materialFolder.getName();
+		String materialId = matrialId(materialFolder);
 		this.geometryNode = geometryNode;
 		this.assetName = assetName;
 		this.document = document;
-		if (!materialAlreadyInLibrary(materialName)) {
-			createEnclosingTags(materialName);
+		if (!materialAlreadyInLibrary(materialId)) {
+			createEnclosingTags(materialId);
 			addPhongType(materialFolder);
-			addMaterialToLibrary(materialFolder);
+			addMaterialToLibrary(materialFolder, materialId);
 			addEffectToLibrary();
 		}
-		addMaterialReferenceToGeometry(materialFolder, materialSymbol);
+		addMaterialReferenceToGeometry(materialId, materialSymbol);
 	}
 
 
-	private void createEnclosingTags(String materialName) {
+	private void createEnclosingTags(String materialId) {
 		effect = new EffectType();
 		profile = new ProfileCommonType();
 		technique = new Technique();
 		profile.setTechnique(technique);
 
-		effect.setId(materialName + "-effect");
+		effect.setId(materialId + "-effect");
 		effect.getProfileCOMMONsAndProfileBRIDGEsAndProfileGLES2s().add(profile);
 	}
 
-	private void addMaterialReferenceToGeometry(Folder materialFolder, String materialSymbol) {
+	private void addMaterialReferenceToGeometry(String materialId, String materialSymbol) {
 		BindMaterialType bind = new BindMaterialType();
 		BindMaterialType.TechniqueCommon matTechnique = new BindMaterialType.TechniqueCommon();
 		InstanceMaterialType matRef = new InstanceMaterialType();
 		matRef.setSymbol(materialSymbol);
-		matRef.setTarget("#" + materialFolder.getName());
+		matRef.setTarget("#" + materialId);
 		matTechnique.getInstanceMaterials().add(matRef);
 		bind.setTechniqueCommon(matTechnique);
 		geometryNode.setBindMaterial(bind);
@@ -84,13 +84,12 @@ public class ColladaMaterialExporter {
 		document.getLibrary(LibraryEffectsType.class).getEffects().add(effect);
 	}
 
-	private void addMaterialToLibrary(Folder materialFolder) {
-		String matName = materialFolder.getName();
+	private void addMaterialToLibrary(Folder materialFolder, String materialId) {
 		MaterialType mat = new MaterialType();
-		mat.setId(matName);
-		mat.setName(matName);
+		mat.setId(materialId);
+		mat.setName(materialFolder.getName());
 		InstanceEffectType instanceEffect = new InstanceEffectType();
-		instanceEffect.setUrl("#" + matName + "-effect");
+		instanceEffect.setUrl("#" + materialId + "-effect");
 		mat.setInstanceEffect(instanceEffect);
 		document.getLibrary(LibraryMaterialsType.class).getMaterials().add(mat);
 	}
@@ -200,14 +199,18 @@ public class ColladaMaterialExporter {
 		return colorType;
 	}
 
-	private boolean materialAlreadyInLibrary(final String materialName) {
+	private boolean materialAlreadyInLibrary(final String materialId) {
 		List<MaterialType> mats = document.getLibrary(LibraryMaterialsType.class).getMaterials();
 		MaterialType mat = CollectionUtils.find(mats, new Predicate<MaterialType>() {
 			@Override
 			public boolean evaluate(MaterialType t) {
-				return t.getId().equals(materialName);
+				return t.getId().equals(materialId);
 			}
 		});
 		return (mat != null);
+	}
+
+	private String matrialId(Folder materialFolder) {
+		return materialFolder.getName();
 	}
 }

--- a/src/main/java/de/dfki/asr/atlas/convert/xml3d/XML3DMeshExporter.java
+++ b/src/main/java/de/dfki/asr/atlas/convert/xml3d/XML3DMeshExporter.java
@@ -12,16 +12,17 @@ import de.dfki.asr.xml3d.jaxb.Defs;
 import de.dfki.asr.xml3d.jaxb.Shader;
 import de.dfki.asr.xml3d.jaxb.IntList;
 import de.dfki.asr.atlas.business.AssetManager;
+import de.dfki.asr.atlas.business.FolderHasher;
 import de.dfki.asr.atlas.convert.ExportContext;
 import de.dfki.asr.atlas.convert.ExporterUtils;
 import de.dfki.asr.atlas.convert.FloatStreamIterator;
 import de.dfki.asr.atlas.convert.IntStreamIterator;
 import de.dfki.asr.atlas.model.*;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.IteratorUtils;
+import org.apache.commons.collections4.Predicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,7 +33,6 @@ public class XML3DMeshExporter {
 	protected AssetManager manager;
 	protected Defs defs;
 	protected ExportContext context;
-	private final Map<String, String> addedShaders = new HashMap<>();
 	private final List<String> usedAssetmeshNames = new ArrayList<>();
 	private long id = 1;
 
@@ -176,34 +176,25 @@ public class XML3DMeshExporter {
 	}
 
 	private String addShaderToDefs(Folder materialFolder){
-		String materialName = materialFolder.getName();
-		if( addedShaders.containsKey(materialName) ){
-			return addedShaders.get(materialName);
+		String materialId = "shader-" + new FolderHasher(materialFolder).toString();
+		if (shaderAlreadyAdded(materialId)) {
+			return materialId;
 		}
-		String materialId = generateShaderId(materialName);
 		XML3DShaderExporter shaderExporter = new XML3DShaderExporter(context);
 		Shader shader = shaderExporter.exportShader(materialFolder);
 		shader.setId(materialId);
 		defs.getShaders().add(shader);
-		addedShaders.put(materialName, materialId);
 		return materialId;
 	}
 
-	private String generateShaderId(String materialName){
-		if( stringIsValidHTMLId(materialName) ){
-			return materialName;
-		}else{
-			return "shader_" + generateNewIDSuffix();
-		}
-	}
-
-	private boolean stringIsValidHTMLId(String str){
-		//ID must start with a letter A-Z or a-z.
-		//Furthermore use only the following: letters A-Z and a-z, numbers 0-9, undercore _ , colon : and hyphen -
-		//It must not use any other special characters
-		//We do not allow the dot character, since it breaks all jquery selectors used within xml3d
-		String regex = "[A-Za-z][A-Za-z0-9_:-]*";
-		return str.matches(regex);
+	private boolean shaderAlreadyAdded(final String shaderId) {
+		Shader existing = CollectionUtils.find(defs.getShaders(), new Predicate<Shader>() {
+			@Override
+			public boolean evaluate(Shader t) {
+				return t.getId().equals(shaderId);
+			}
+		});
+		return existing != null;
 	}
 
 	private ArrayMatrix4f readGlobalTransform(Folder folder) {

--- a/src/main/java/de/dfki/asr/atlas/model/Folder.java
+++ b/src/main/java/de/dfki/asr/atlas/model/Folder.java
@@ -24,17 +24,17 @@ public class Folder implements Serializable {
 	protected String type;
 
 	@JsonManagedReference
-	protected List<Folder> children;
+	protected List<Folder> children = new ArrayList<>();
 
 	@JsonBackReference
 	@Getter @Setter
 	protected Folder parent;
 
 	@JsonProperty
-	protected Map<String, String> blobs;
+	protected Map<String, String> blobs = new HashMap<>();
 
 	@JsonProperty
-	protected Map<String, String> attributes;
+	protected Map<String, String> attributes = new HashMap<>();
 
 	public void setName(String name) {
 		this.name = name;

--- a/src/test/java/de/dfki/asr/atlas/test/FolderAddressTest.java
+++ b/src/test/java/de/dfki/asr/atlas/test/FolderAddressTest.java
@@ -7,7 +7,6 @@
 package de.dfki.asr.atlas.test;
 
 import de.dfki.asr.atlas.model.Folder;
-import java.util.ArrayList;
 import java.util.List;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -20,7 +19,6 @@ public class FolderAddressTest {
 	@BeforeClass
 	public void setupFolderHierarchy() {
 		rootFolder = new Folder();
-		rootFolder.setChildren(new ArrayList<Folder>());
 		firstChild = new Folder();
 		rootFolder.getChildFolders().add(firstChild);
 		firstChild.setParent(rootFolder);
@@ -29,7 +27,6 @@ public class FolderAddressTest {
 		secondChild.setParent(rootFolder);
 		grandChild = new Folder();
 		// append grandchild to second to test list ordering
-		secondChild.setChildren(new ArrayList<Folder>());
 		secondChild.getChildFolders().add(grandChild);
 		grandChild.setParent(secondChild);
 	}

--- a/src/test/java/de/dfki/asr/atlas/test/FolderHashTest.java
+++ b/src/test/java/de/dfki/asr/atlas/test/FolderHashTest.java
@@ -1,0 +1,101 @@
+/*
+ * This file is part of ATLAS. It is subject to the license terms in
+ * the LICENSE file found in the top-level directory of this distribution.
+ * (Also available at http://www.apache.org/licenses/LICENSE-2.0.txt)
+ * You may not use this file except in compliance with the License.
+ */
+package de.dfki.asr.atlas.test;
+
+import de.dfki.asr.atlas.business.FolderHasher;
+import de.dfki.asr.atlas.model.Folder;
+import org.testng.annotations.Test;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import org.testng.annotations.BeforeClass;
+
+public class FolderHashTest {
+	Folder empty;
+
+	@BeforeClass
+	public void setUp() {
+		empty = new Folder();
+		empty.setType("node");
+		empty.setName("Empty Node Folder");
+	}
+
+	@Test
+	public void emptyFolderShouldHash() {
+		FolderHasher hash = new FolderHasher(empty);
+		// computed using: `echo "# node" |shasum`
+		assertThat(hash.toString(), is("168b7940ff34daeeacfe15e80b915d5970708486"));
+	}
+
+	@Test
+	public void differentNameDoesntMatter() {
+		Folder named = new Folder();
+		named.setType("node");
+		named.setName("Very Differently Named Folder");
+		FolderHasher hash_a = new FolderHasher(named);
+		FolderHasher hash_b = new FolderHasher(empty);
+		assertThat(hash_a.toString(), is(hash_b.toString()));
+	}
+
+	@Test
+	public void withBlobs() {
+		Folder blobbed = new Folder();
+		blobbed.setType("node");
+		// fake idendity transform
+		blobbed.getBlobs().put("transform", "40126e70d1873c3c3306b219aafe18f9daf7580b");
+		FolderHasher hash = new FolderHasher(blobbed);
+		// shasum
+		// # node
+		// transform 40126e70d1873c3c3306b219aafe18f9daf7580b
+		// ^D
+		assertThat(hash.toString(), is("5a1ded219760b97fd5e5092d4381eb34f42d93ba"));
+	}
+
+	@Test
+	public void withChild() {
+		Folder parent = new Folder();
+		parent.setType("node");
+		parent.getChildFolders().add(empty);
+		FolderHasher hash = new FolderHasher(parent);
+		// shasum
+		// # node
+		// folder 168b7940ff34daeeacfe15e80b915d5970708486
+		// ^D
+		assertThat(hash.toString(), is("d30f76d0a27bd2f2cb679c0b17454902c129432f"));
+	}
+
+	@Test
+	public void withAttribute() {
+		Folder attributed = new Folder();
+		attributed.setType("node");
+		attributed.getAttributes().put("herp", "derp");
+		FolderHasher hash = new FolderHasher(attributed);
+		// shasum
+		// # node
+		// # herp: derp
+		// ^D
+		assertThat(hash.toString(), is("c500ad6f305d5c7578fa3e5b9a403cc78d98981c"));
+	}
+
+	@Test
+	public void allTogetherNow() {
+		Folder chockFull = new Folder();
+		chockFull.setType("node");
+		chockFull.getAttributes().put("herp", "derp");
+		chockFull.getChildFolders().add(empty);
+		chockFull.getBlobs().put("transform", "40126e70d1873c3c3306b219aafe18f9daf7580b");
+		chockFull.getBlobs().put("identity", "40126e70d1873c3c3306b219aafe18f9daf7580b");
+		FolderHasher hash = new FolderHasher(chockFull);
+		// shasum
+		// # node
+		// folder 168b7940ff34daeeacfe15e80b915d5970708486
+		// identity 40126e70d1873c3c3306b219aafe18f9daf7580b
+		// transform 40126e70d1873c3c3306b219aafe18f9daf7580b
+		// # herp: derp
+		// ^D
+		assertThat(hash.toString(), is("12caf0ad39a2e53b0f3f5caa0efd43daf63fe791"));
+	}
+}


### PR DESCRIPTION
This feature reworks the encoding of shaders in XML3D and Collada. Material names are no longer regarded as unique, and therefore no longer used as IDs to be referenced.
As a replacement, Folder Hashes are introduced. Similarliy to GIT's "tree hashes", these give a unique identifier to a given (content) subtree of the folder structure.
In consequence, materials/shaders using the same parameters are combined in the output file by virtue of having the same folder hash, for each of which only one definition is added to the output.

This also fixes a bug, where when multiple different, but equally-named materials would erroneously be combined into the same material. In that case, the first of these took precedence.
