### PR TITLE
Feature/pretty json

### DIFF
--- a/src/main/java/de/dfki/asr/atlas/rest/providers/JacksonPrettyPrintProvider.java
+++ b/src/main/java/de/dfki/asr/atlas/rest/providers/JacksonPrettyPrintProvider.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of ATLAS. It is subject to the license terms in
+ * the LICENSE file found in the top-level directory of this distribution.
+ * (Also available at http://www.apache.org/licenses/LICENSE-2.0.txt)
+ * You may not use this file except in compliance with the License.
+ */
+package de.dfki.asr.atlas.rest.providers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+@Produces(MediaType.APPLICATION_JSON)
+public class JacksonPrettyPrintProvider implements ContextResolver<ObjectMapper> {
+	private ObjectMapper mapper;
+
+	public JacksonPrettyPrintProvider() {
+		mapper = new ObjectMapper();
+		mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
+	}
+
+
+	@Override
+	public ObjectMapper getContext(Class<?> type) {
+		return mapper;
+	}
+	
+}

--- a/src/main/java/de/dfki/asr/atlas/rest/providers/JacksonPrettyPrintProvider.java
+++ b/src/main/java/de/dfki/asr/atlas/rest/providers/JacksonPrettyPrintProvider.java
@@ -23,10 +23,8 @@ public class JacksonPrettyPrintProvider implements ContextResolver<ObjectMapper>
 		mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
 	}
 
-
 	@Override
 	public ObjectMapper getContext(Class<?> type) {
 		return mapper;
 	}
-	
 }


### PR DESCRIPTION
This PR adds a JAX-RS provider which configures the JSON output to be pretty-printed.

Previously, JSON would be output without any whitespace. Funnily enough, this leads to complications when trying to parse said json again using Jackson (which seems to have an internal buffer cutting off at some arbitrary point). The latter does not occur when linebreaks are properly inserted into the generated JSON.
