### PR TITLE
Feature/improved JSON transport

### DIFF
--- a/src/main/java/de/dfki/asr/atlas/convert/SubassetListingExporter.java
+++ b/src/main/java/de/dfki/asr/atlas/convert/SubassetListingExporter.java
@@ -38,6 +38,10 @@ public class SubassetListingExporter implements ExportOperation<ListingFolder>{
 			parentAsset.getChildren().add(subasset);
 			for (Folder child : currentFolder.getChildFolders()) {
 				convertFolder(child, subasset);
+				if (child.getType().equals("mesh")) {
+					// any mesh triggers flag
+					subasset.setHasGeometry(true);
+				}
 			}
 		}
 	}

--- a/src/main/java/de/dfki/asr/atlas/convert/SubassetListingExporter.java
+++ b/src/main/java/de/dfki/asr/atlas/convert/SubassetListingExporter.java
@@ -14,12 +14,10 @@ import de.dfki.asr.atlas.model.ListingFolder;
 @AtlasExporter(contentType = "application/json", fileExtension = ".json", folderTypes = {"node"})
 public class SubassetListingExporter implements ExportOperation<ListingFolder>{
 
-	private Asset currentAsset;
 	private ExportContext context;
 
 	@Override
 	public ListingFolder export(ExportContext context) {
-		currentAsset = context.getSourceAsset();
 		this.context = context;
 		Folder root = context.getStartingFolder();
 		ListingFolder assetListing = createListingFromFolder(root);

--- a/src/main/java/de/dfki/asr/atlas/convert/SubassetListingExporter.java
+++ b/src/main/java/de/dfki/asr/atlas/convert/SubassetListingExporter.java
@@ -7,7 +7,7 @@
 package de.dfki.asr.atlas.convert;
 
 import de.dfki.asr.atlas.cdi.annotations.AtlasExporter;
-import de.dfki.asr.atlas.model.Asset;
+import de.dfki.asr.atlas.model.ArrayMatrix4f;
 import de.dfki.asr.atlas.model.Folder;
 import de.dfki.asr.atlas.model.ListingFolder;
 
@@ -50,6 +50,11 @@ public class SubassetListingExporter implements ExportOperation<ListingFolder>{
 		ListingFolder subasset = new ListingFolder();
 		subasset.setName(folder.getName());
 		subasset.setUrl(buildURLForFolder(folder));
+		subasset.setTransform(readLocalTransform(folder));
 		return subasset;
+	}
+
+	private ArrayMatrix4f readLocalTransform(Folder folder) {
+		return ExporterUtils.readTransform(folder, "transform", context);
 	}
 }

--- a/src/main/java/de/dfki/asr/atlas/convert/xml3d/XML3DMeshExporter.java
+++ b/src/main/java/de/dfki/asr/atlas/convert/xml3d/XML3DMeshExporter.java
@@ -82,7 +82,7 @@ public class XML3DMeshExporter {
 
 	private void addTransformMatrixToMesh(Assetmesh mesh, ArrayMatrix4f matrix) {
 		FloatList matrixFloatList = new FloatList("meshTransform");
-		matrixFloatList.setValues(matrix.asList());
+		matrixFloatList.setValues(matrix.asListColumnMajor());
 		mesh.setTransform(matrixFloatList);
 	}
 

--- a/src/main/java/de/dfki/asr/atlas/model/ArrayMatrix4f.java
+++ b/src/main/java/de/dfki/asr/atlas/model/ArrayMatrix4f.java
@@ -33,7 +33,7 @@ public class ArrayMatrix4f extends Matrix4f {
 
 	}
 
-	public List<Float> asList() {
+	public List<Float> asListColumnMajor() {
 		List<Float> list = new ArrayList<>();
 		for (int i = 0; i < 16; i++) {
 			list.add(getElement(i % 4, i / 4));

--- a/src/main/java/de/dfki/asr/atlas/model/ArrayMatrix4f.java
+++ b/src/main/java/de/dfki/asr/atlas/model/ArrayMatrix4f.java
@@ -6,11 +6,14 @@
  */
 package de.dfki.asr.atlas.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import javax.vecmath.Matrix4f;
 
+@JsonIgnoreProperties({"m00","m01","m02","m03","m10","m11","m12","m13","m20","m21","m22","m23","m30","m31","m32","m33"})
 public class ArrayMatrix4f extends Matrix4f {
 	private static final long serialVersionUID = 5264274544357406927L;
 
@@ -37,6 +40,15 @@ public class ArrayMatrix4f extends Matrix4f {
 		List<Float> list = new ArrayList<>();
 		for (int i = 0; i < 16; i++) {
 			list.add(getElement(i % 4, i / 4));
+		}
+		return list;
+	}
+
+	@JsonValue
+	public List<Float> asListRowMajor() {
+		List<Float> list = new ArrayList<>();
+		for (int i = 0; i < 16; i++) {
+			list.add(getElement(i / 4, i % 4));
 		}
 		return list;
 	}

--- a/src/main/java/de/dfki/asr/atlas/model/ListingFolder.java
+++ b/src/main/java/de/dfki/asr/atlas/model/ListingFolder.java
@@ -26,8 +26,20 @@ public class ListingFolder implements Serializable {
 	@JsonProperty
 	protected List<ListingFolder> children;
 
+	@JsonProperty
+	protected boolean hasGeometry;
+
+	public boolean hasGeometry() {
+		return hasGeometry;
+	}
+
+	public void setHasGeometry(boolean hasGeometry) {
+		this.hasGeometry = hasGeometry;
+	}
+
 	public ListingFolder() {
 		children = new ArrayList<>();
+		hasGeometry = false;
 	}
 
 	public String getName() {

--- a/src/main/java/de/dfki/asr/atlas/model/ListingFolder.java
+++ b/src/main/java/de/dfki/asr/atlas/model/ListingFolder.java
@@ -21,6 +21,9 @@ public class ListingFolder implements Serializable {
 	protected String url;
 
 	@JsonProperty
+	protected ArrayMatrix4f transform;
+
+	@JsonProperty
 	protected List<ListingFolder> children;
 
 	public ListingFolder() {
@@ -41,6 +44,14 @@ public class ListingFolder implements Serializable {
 
 	public void setUrl(String url) {
 		this.url = url;
+	}
+
+	public ArrayMatrix4f getTransform() {
+		return transform;
+	}
+
+	public void setTransform(ArrayMatrix4f transform) {
+		this.transform = transform;
 	}
 
 	public List<ListingFolder> getChildren() {


### PR DESCRIPTION
This PR adds the "transform" and "hasGeometry" properties to the `ListingFolder` class, and conversely, the JSON variant of an asset.
This is very useful when implementing integrations on top of ATLAS. When discovering the structure of an asset, one can discern which nodes are purely structural (`hasGeometry: false`) and which aren't. Also, the spatial hierarchy can be reconstructed from the "transform" attribute.  
